### PR TITLE
Convert readthedocs link for their .org -> .io migration for hosted projects

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -5,7 +5,7 @@
 |build-status| |coverage|
 
 :Version: 1.1.0
-:Web: http://cyanide.readthedocs.org/
+:Web: https://cyanide.readthedocs.io/
 :Download: http://pypi.python.org/pypi/cyanide/
 :Source: http://github.com/celery/cyanide/
 :Keywords: celery, stress, integration, functional, testing

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -10,7 +10,7 @@ globals().update(conf.build_config(
     project='Cyanide',
     # version_dev='2.0',
     # version_stable='1.4',
-    canonical_url='http://cyanide.readthedocs.org',
+    canonical_url='https://cyanide.readthedocs.io',
     webdomain='',
     github_project='celery/cyanide',
     copyright='2013-2016',

--- a/docs/includes/introduction.txt
+++ b/docs/includes/introduction.txt
@@ -1,5 +1,5 @@
 :Version: 1.1.0
-:Web: http://cyanide.readthedocs.org/
+:Web: https://cyanide.readthedocs.io/
 :Download: http://pypi.python.org/pypi/cyanide/
 :Source: http://github.com/celery/cyanide/
 :Keywords: celery, stress, integration, functional, testing


### PR DESCRIPTION
As per their email ‘Changes to project subdomains’:

> Starting today, Read the Docs will start hosting projects from subdomains on the domain readthedocs.io, instead of on readthedocs.org. This change addresses some security concerns around site cookies while hosting user generated data on the same domain as our dashboard.

Test Plan: Manually visited all the links I’ve modified.

Also the github repo link needs updating.
